### PR TITLE
Add an option to start peregrine server with debugging

### DIFF
--- a/bin/percli-server-start
+++ b/bin/percli-server-start
@@ -10,18 +10,19 @@ args.version('1.0.0')
     .option('-a, --author', 'start as author')
     .option('-s, --standalone', 'start as standalone')
     .option('-p, --publish', 'start as publish')
+    .option('-d, --debug', 'start with debugging enabled (default port=30303)')
     .option('-n, --name [name]', 'start server by name')
     .parse(process.argv)
 
 async function serverStart(type){
 	await peregrineBanner()
-	startPeregrine(type)
+	startPeregrine(type, args.debug)
 }
 
 async function runPromptAndStart(type) {
     await peregrineBanner()
 	const inputName = await promptAddServer(process.cwd())
-	startPeregrine(type)
+	startPeregrine(type, args.debug)
     if (!getPathForServer(inputName)) {
         addServer(inputName, process.cwd())
         console.log('Registering server '+inputName+' to path: '+process.cwd())

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -13,9 +13,13 @@ let port = 8080
     * Starts up the sling instance
     * @param {string} type - the run mode(standalone, author, publish)
 */
-function startSling(type) {
+function startSling(type, debug) {
+    const args = [ '-jar','out/sling-9.jar', 'start'];
 
-    const args = ['-jar','out/sling-9.jar', 'start'];
+    if(debug) {
+        args.unshift("-agentlib:jdwp=transport=dt_socket,address=30303,server=y,suspend=n")
+        args.unshift("-Xdebug")
+    }
 
     if(type === 'standalone') {
         // do nothing
@@ -252,10 +256,10 @@ module.exports = {
         * @param {String} type - the run mode
         * @return {string} a new promise
     */
-    startPeregrine(type) {
+    startPeregrine(type,debug) {
         return new Promise((resolve, reject) => checkIfRunning().then(() => {
             console.log('sling is not running')
-            startSling(type)
+            startSling(type,debug)
             waitUntilRunning().then((msg) => {
                 console.log(msg)
                 setTimeout( () => { open("http://localhost:"+port+"/index.html") }, 2000);


### PR DESCRIPTION
Add the following arguments when starting the server to allow us to attach a debugger to sling on port 30303
-Xdebug -agentlib:jdwp=transport=dt_socket,address=30303,server=y,suspend=n