### PR TITLE
Fixed: Set the port defined in sling.properties for the standalone server

### DIFF
--- a/bin/percli-server-start
+++ b/bin/percli-server-start
@@ -91,7 +91,7 @@ function getSlingPort(slingPropertiesPath) {
           }
       }
   } catch(err) {
-      console.error('Unable to fetch the sling.properties file, thus using the default port as 8080')
+      console.log('Unable to fetch the sling.properties file, thus using the default port as 8080')
   }
   return port
 }

--- a/bin/percli-server-start
+++ b/bin/percli-server-start
@@ -34,7 +34,7 @@ async function runPromptAndStart(type) {
         }
     } catch(error) {
         console.error(error);
-    } 
+    }
 }
 
 if(typeof args.name === 'string') {
@@ -46,15 +46,7 @@ if(typeof args.name === 'string') {
     const serverPath = getPathForServer(args.name)
     if(serverPath) {
         try {
-            let port = 8080
-            const file = fs.readFileSync(path.join(serverPath, 'sling', 'sling.properties')).toString()
-            lines = file.split(/[\n\r]/)
-            for(let i = 0; i < lines.length; i++) {
-                if(lines[i].startsWith('org.osgi.service.http.port=')) {
-                    const prop = lines[i].split('=')
-                    port = prop[1]
-                }
-            }
+            let port = getSlingPort(path.join(serverPath, 'sling', 'sling.properties'))
             setPort(port)
             process.chdir(serverPath)
             serverStart('standalone')
@@ -71,6 +63,8 @@ if(typeof args.name === 'string') {
         setPort(8180)
         serverStart('publish')
     } else {
+        let port = getSlingPort(path.join('sling', 'sling.properties'))
+        setPort(port)
         serverStart('standalone')
     }
 } else {
@@ -83,4 +77,17 @@ if(typeof args.name === 'string') {
     } else {
         runPromptAndStart('standalone')
     }
+}
+
+function getSlingPort(slingPropertiesPath) {
+  let port = 8080
+  const file = fs.readFileSync(slingPropertiesPath).toString()
+  lines = file.split(/[\n\r]/)
+  for(let i = 0; i < lines.length; i++) {
+      if(lines[i].startsWith('org.osgi.service.http.port=')) {
+          const prop = lines[i].split('=')
+          port = prop[1]
+      }
+  }
+  return port
 }

--- a/bin/percli-server-start
+++ b/bin/percli-server-start
@@ -90,7 +90,7 @@ function getSlingPort(slingPropertiesPath) {
               port = prop[1]
           }
       }
-  }  catch(err) {
+  } catch(err) {
       console.error('Unable to fetch the sling.properties file, thus using the default port as 8080')
   }
   return port

--- a/bin/percli-server-start
+++ b/bin/percli-server-start
@@ -81,13 +81,17 @@ if(typeof args.name === 'string') {
 
 function getSlingPort(slingPropertiesPath) {
   let port = 8080
-  const file = fs.readFileSync(slingPropertiesPath).toString()
-  lines = file.split(/[\n\r]/)
-  for(let i = 0; i < lines.length; i++) {
-      if(lines[i].startsWith('org.osgi.service.http.port=')) {
-          const prop = lines[i].split('=')
-          port = prop[1]
+  try {
+      const file = fs.readFileSync(slingPropertiesPath).toString()
+      lines = file.split(/[\n\r]/)
+      for(let i = 0; i < lines.length; i++) {
+          if(lines[i].startsWith('org.osgi.service.http.port=')) {
+              const prop = lines[i].split('=')
+              port = prop[1]
+          }
       }
+  }  catch(err) {
+      console.error('Unable to fetch the sling.properties file, thus using the default port as 8080')
   }
   return port
 }


### PR DESCRIPTION
When we change the port in sling.properties, let say for e.g. port is changed to 8084
And start the standalone server via command - percli server start

The server is started properly at 8084, but the message

**'waiting for sling to start'**

shown continuously on the console, and thus the Peregrine CMS has not launched on browser automatically.

### Issue

The issue is checkIfRunning function is using hardcoded port 8080 and trying to access sling at 8080.

### Done following

1. Implemented the getSlingPort function, which takes the path of sling.properties file and return the port defined in this file.

2. Call the getSlingPort function for the standalone server to get the port of sling, and set it via setPort method.

3. Moved the common code in getSlingPort function and call it wherever needed.