### PR TITLE
Fixed issues with JSON properties

### DIFF
--- a/lib/functions.js
+++ b/lib/functions.js
@@ -859,9 +859,13 @@ const f = {
             if (Array.isArray(value)) {
                 var collection = content.ele(key).att('jcr:primaryType','nt:unstructured')
                 for(var i = 0; i < value.length; i++) {
-                    var children = collection.ele(key+i).att('jcr:primaryType','nt:unstructured')
-                    for (childKey in value[i])
-                    children.att(childKey, value[i][childKey])
+                    var children = collection.ele(key+i).att('jcr:primaryType','fnt:unstructured')
+                    for (childKey in value[i]) {
+                        if(value[i][childKey].startsWith('{'))
+                            children.att(childkey, '\\' + value[i][childKey])
+                        else
+                            children.att(childKey, value[i][childKey])
+                    }
                 }
             } else {
                 content.att(key,value)
@@ -891,11 +895,18 @@ const f = {
                 var collection = versionContent.ele(key).att('jcr:primaryType','nt:unstructured')
                 for(var i = 0; i < value.length; i++) {
                     var children = collection.ele(key+i).att('jcr:primaryType','nt:unstructured')
-                    for (childKey in value[i])
-                    children.att(childKey, value[i][childKey])
+                    for (childKey in value[i]) {
+                        if(value[i][childKey].startsWith('{'))
+                            children.att(childkey, '\\' + value[i][childKey])
+                        else
+                            children.att(childKey, value[i][childKey])
+                    }
                 }
             } else {
-                versionContent.att(key,value)
+                if(value.toString().startsWith('{'))
+                    versionContent.att(key,'\\' + value)
+                else
+                    versionContent.att(key, value)
             }
         }
         return xml

--- a/lib/functions.js
+++ b/lib/functions.js
@@ -859,7 +859,7 @@ const f = {
             if (Array.isArray(value)) {
                 var collection = content.ele(key).att('jcr:primaryType','nt:unstructured')
                 for(var i = 0; i < value.length; i++) {
-                    var children = collection.ele(key+i).att('jcr:primaryType','fnt:unstructured')
+                    var children = collection.ele(key+i).att('jcr:primaryType','nt:unstructured')
                     for (childKey in value[i]) {
                         if(value[i][childKey].startsWith('{'))
                             children.att(childkey, '\\' + value[i][childKey])

--- a/lib/htmltovue.js
+++ b/lib/htmltovue.js
@@ -120,7 +120,9 @@ function htmltovue(name, container, compile, deploy, dialog, model, vue, samplee
 
             const templateVue = fs.readFileSync(path.join(componentPath, 'template.vue')).toString()
             const newTemplateVue = templateVue.replace(/^<template>[\s\S]*^<\/template>/m, out).replace(/&apos;/g, '\'')
-            if ((convertVue && templateVue.valueOf() !== newTemplateVue.valueOf()) || (convertVue && !fs.existsSync(path.join(uiAppsComponentPath, 'template.vue')))) {
+            const uiAppsTemplatePath = path.join(uiAppsComponentPath, 'template.vue')
+            const uiAppsTemplateMatches = fs.existsSync(uiAppsTemplatePath) && fs.readFileSync(uiAppsTemplatePath).toString().valueOf() === templateVue.valueOf()
+            if ((convertVue && templateVue.valueOf() !== newTemplateVue.valueOf()) || (convertVue && !uiAppsTemplateMatches)) {
                 fs.writeFileSync(path.join(componentPath, 'template.vue'), newTemplateVue)
 
                 // copy template.vue file to component


### PR DESCRIPTION
Fixed issue with JSON properties as the SAX parser doesn't like attributes starting with a curly bracket character. This change will prepend a backslash to any attributes that start with '{'

Also fixed an unrelated issue with template.vue files not being updated from fragments to ui.apps when there wasn't a change in the hatch.js template output.