### PR TITLE
peregrine-cms#460 - Added the Image Info annotation to the Peregrine Sling Module

### DIFF
--- a/lib/functions.js
+++ b/lib/functions.js
@@ -322,9 +322,9 @@ const f = {
         for(var key in from.properties) {
             var field =from.properties[key]
             if(!field['x-form-ignore']) {
-                var fieldType = field['x-form-type'] ? field['x-form-type'] : field.type
-                var placeholder = field['x-form-placeholder'] ? field['x-form-placeholder'] : key
-                var label = field['x-form-label'] ? field['x-form-label'] : key
+                var fieldType = field['x-form-type'] || field.type
+                var placeholder = field['x-form-placeholder'] || key
+                var label = field['x-form-label'] || key
                 var visible = field['x-form-visible']
                 var hint = field['x-form-hint']
                 var required = field['x-form-required']

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -22,8 +22,10 @@ class Generator {
     * @return {string} the template
 */
 function makeInitial(srcData, generator) {
+    let definitions = generator.data.definitions[generator.data.modelName];
+    let properties = definitions.properties;
     var data = {
-        imports: getImports(),
+        imports: getImports(properties),
         ...generator.data
     }
     var template = srcData.replace(/{{.*?}}/g, function(str, p1, offset, s) {
@@ -39,9 +41,16 @@ function makeInitial(srcData, generator) {
     return template
 }
 
-function getImports() {
-    return 'import com.peregrine.model.api.ImageInfo;\n' + 
-        'import java.awt.Dimension;\n';
+function getImports(properties) {
+    for(var propName in properties) {
+        var props = properties[propName]
+        if (propName !== 'children' && props['x-source'] == 'inject' && props['x-annotate']) {
+            return 'import com.peregrine.model.api.ImageInfo;\n' + 
+                'import java.awt.Dimension;\n';
+        }
+    }
+
+    return ''
 }
 
 /**
@@ -185,17 +194,18 @@ function gen(generator) {
         return str
     })
 
+    let definitions = generator.data.definitions[generator.data.modelName];
+    let properties = definitions.properties;
     for(key in fragments) {
         var name = key.split(':')[1]
         var inject = ''
 
-        let data = generator.data.definitions[generator.data.modelName];
         if('DATA' === name) {
             inject = JSON.stringify(generator.data, true, 2)
         } else if('INJECT' === name) {
-            inject = genNames(data.properties)
+            inject = genNames(properties)
         } else if('GETTERS' === name) {
-            inject = genGetters(data.properties, customGetters)
+            inject = genGetters(properties, customGetters)
         }
 
         fragments[key] = fragments[key].replace('//GEN]', inject+'\n//GEN]')

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -22,16 +22,26 @@ class Generator {
     * @return {string} the template
 */
 function makeInitial(srcData, generator) {
+    var data = {
+        imports: getImports(),
+        ...generator.data
+    }
     var template = srcData.replace(/{{.*?}}/g, function(str, p1, offset, s) {
         var key = str.trim().slice(2,str.trim().length-2).trim()
-        var ret = generator.data[key]
+        var ret = data[key]
         if(!ret) {
             console.log('missing property:', key)
             ret = '!!!'+key+'!!'
         }
         return ret
     })
+
     return template
+}
+
+function getImports() {
+    return 'import com.peregrine.model.api.ImageInfo;\n' + 
+        'import java.awt.Dimension;\n';
 }
 
 /**
@@ -67,12 +77,26 @@ function genNames(properties) {
                 inject += ';'
                 inject += '\n'
                 inject += '\n'
+                if (props['x-annotate']) {
+                    inject += genNamesAnnotates(propName, props['x-annotate'])
+                }
             } else if(props['x-form-type'] === ('reference')) {
                 inject += genNames(props.properties)
             }
         }
     }
     return inject
+}
+
+function genNamesAnnotates(name, values) {
+    var result = ''
+    if (values === 'imagesize') {
+        result += '\t@Inject\n'
+        result += `\t@ImageInfo(name="${name}")\n`
+        result += `\tprivate Dimension ${values};\n\n`
+    }
+
+    return result
 }
 
 /**
@@ -104,12 +128,26 @@ function genGetters(properties, customGetters) {
                 inject += '\t}'
                 inject += '\n'
                 inject += '\n'
+                if (props['x-annotate']) {
+                    inject += genGettersAnnotates(propName, props['x-annotate'])
+                }
             } else if(props['x-form-type'] === ('reference')) {
                 inject += genGetters(props.properties, customGetters)
             }
         }
     }
     return inject
+}
+
+function genGettersAnnotates(name, values) {
+    var result = ''
+    if (values === 'imagesize') {
+        result += `\tpublic Dimension get${values.charAt(0).toUpperCase()}${values.slice(1)}() {\n`
+        result += `\t\treturn ${values};\n`
+        result += '\t}\n\n'
+    }
+
+    return result
 }
 
 /**

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -1,4 +1,5 @@
 const fs = require('fs')
+const path = require('path')
 
 /** Class representing the sling model generator */
 class Generator {
@@ -90,7 +91,12 @@ function genNames(properties) {
                 }
                 if(props['x-form-type'] === 'collection') {
                     if (Object.keys(props['properties']).length > 1 || props['x-form-multifield'] === "true" || props['x-form-multifield'] === true) {
-                        inject += '\tprivate List<IComponent> '
+                        var collectionType = props['x-collection-type']
+                        if (collectionType) {
+                            inject += `\tprivate List<${collectionType}Model> `
+                        } else {
+                            inject += '\tprivate List<IComponent> '
+                        }
                     } else {
                         inject += '\tprivate String[] '
                     }
@@ -137,7 +143,12 @@ function genGetters(properties, customGetters) {
                 inject += `\t/* ${JSON.stringify(props)} */\n`
                 if(props['x-form-type'] === 'collection') {
                      if (Object.keys(props['properties']).length > 1 || props['x-form-multifield'] === "true" || props['x-form-multifield'] === true) {
-                        inject += '\tpublic List<IComponent> get'
+                        var collectionType = props['x-collection-type']
+                        if (collectionType) {
+                            inject += `\tpublic List<${collectionType}Model> get`
+                        } else {
+                            inject += '\tpublic List<IComponent> get'
+                        }
                     } else {
                         inject += '\tpublic String[] get'
                     }
@@ -170,16 +181,40 @@ function genGettersAnnotates(ownerName, annotate) {
     return result
 }
 
+function genTypes(properties, generator) {
+    for(var propName in properties) {
+        if (propName !== 'children') {
+            var props = properties[propName]
+            if(props['x-source'] === 'inject') {
+                if(props['x-form-type'] === 'collection') {
+                    if (Object.keys(props['properties']).length > 1 || props['x-form-multifield'] === "true" || props['x-form-multifield'] === true) {
+                        var collectionType = props['x-collection-type']
+                        if (collectionType) {
+                            gen(new Generator(generator.src, path.join(path.dirname(generator.dst), `${collectionType}Model.java`), {
+                                ...generator.data,
+                                modelName: collectionType,
+                                definitions: {
+                                    [collectionType]: props
+                                }
+                            }))
+                        }
+                    }
+                } 
+            }
+        }
+    }
+    
+}
+
 /**
     * Loads in the sling model template and fills in the data, inject, and getters content to make the components model
     * @param {string} generator - the generator object
 */
 function gen(generator) {
-
     // load the template
     var srcData = fs.readFileSync(generator.src).toString()
 
-    // now substitute all the values we know into the template
+    // substitute all the values we know into the template
     srcData = makeInitial(srcData, generator)
 
     // if the generated file does not exist yet, create it with the template we just created
@@ -242,6 +277,8 @@ function gen(generator) {
     } catch(error) {
         fs.writeFileSync(generator.dst, dstCurrent)
     }
+
+    genTypes(properties, generator)
 }
 
 module.exports = {

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -162,7 +162,7 @@ function genGettersAnnotates(values) {
     for(var name in values) {
         if (values[name] === "imagesize") {
             result += `\tpublic Dimension get${name.charAt(0).toUpperCase()}${name.slice(1)}() {\n`
-            result += `\t\treturn ${values};\n`
+            result += `\t\treturn ${name};\n`
             result += '\t}\n\n'
         }
     }

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -44,9 +44,14 @@ function makeInitial(srcData, generator) {
 function getImports(properties) {
     for(var propName in properties) {
         var props = properties[propName]
-        if (propName !== 'children' && props['x-source'] == 'inject' && props['x-annotate']) {
-            return 'import com.peregrine.model.api.ImageInfo;\n' + 
-                'import java.awt.Dimension;\n';
+        var annotate = props['x-annotate']
+        if (propName !== 'children' && props['x-source'] == 'inject' && annotate) {
+            for(var annotatePropName in annotate) {
+                if (annotate[annotatePropName] === "imagesize") {
+                    return 'import com.peregrine.model.api.ImageInfo;\n' + 
+                        'import java.awt.Dimension;\n';
+                }
+            }
         }
     }
 
@@ -86,8 +91,9 @@ function genNames(properties) {
                 inject += ';'
                 inject += '\n'
                 inject += '\n'
-                if (props['x-annotate']) {
-                    inject += genNamesAnnotates(propName, props['x-annotate'])
+                var annotate = props['x-annotate']
+                if (annotate) {
+                    inject += genNamesAnnotates(propName, annotate)
                 }
             } else if(props['x-form-type'] === ('reference')) {
                 inject += genNames(props.properties)
@@ -97,12 +103,14 @@ function genNames(properties) {
     return inject
 }
 
-function genNamesAnnotates(name, values) {
+function genNamesAnnotates(ownerName, values) {
     var result = ''
-    if (values === 'imagesize') {
-        result += '\t@Inject\n'
-        result += `\t@ImageInfo(name="${name}")\n`
-        result += `\tprivate Dimension ${values};\n\n`
+    for(var name in values) {
+        if (values[name] === "imagesize") {
+            result += '\t@Inject\n'
+            result += `\t@ImageInfo(name="${ownerName}")\n`
+            result += `\tprivate Dimension ${name};\n\n`
+        }
     }
 
     return result
@@ -137,8 +145,9 @@ function genGetters(properties, customGetters) {
                 inject += '\t}'
                 inject += '\n'
                 inject += '\n'
-                if (props['x-annotate']) {
-                    inject += genGettersAnnotates(propName, props['x-annotate'])
+                var annotate = props['x-annotate']
+                if (annotate) {
+                    inject += genGettersAnnotates(annotate)
                 }
             } else if(props['x-form-type'] === ('reference')) {
                 inject += genGetters(props.properties, customGetters)
@@ -148,12 +157,14 @@ function genGetters(properties, customGetters) {
     return inject
 }
 
-function genGettersAnnotates(name, values) {
+function genGettersAnnotates(values) {
     var result = ''
-    if (values === 'imagesize') {
-        result += `\tpublic Dimension get${values.charAt(0).toUpperCase()}${values.slice(1)}() {\n`
-        result += `\t\treturn ${values};\n`
-        result += '\t}\n\n'
+    for(var name in values) {
+        if (values[name] === "imagesize") {
+            result += `\tpublic Dimension get${name.charAt(0).toUpperCase()}${name.slice(1)}() {\n`
+            result += `\t\treturn ${values};\n`
+            result += '\t}\n\n'
+        }
     }
 
     return result

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -22,18 +22,19 @@ class Generator {
     * @return {string} the template
 */
 function makeInitial(srcData, generator) {
-    let definitions = generator.data.definitions[generator.data.modelName];
-    let properties = definitions.properties;
+    let definitions = generator.data.definitions[generator.data.modelName]
+    let properties = definitions.properties
     var data = {
-        imports: getImports(properties),
+        imports: genImports(properties),
         ...generator.data
     }
-    var template = srcData.replace(/{{.*?}}/g, function(str, p1, offset, s) {
+
+    var template = srcData.replace(/{{.*?}}/g, function(str, _, _, _) {
         var key = str.trim().slice(2,str.trim().length-2).trim()
         var ret = data[key]
         if(ret === null || ret === undefined) {
             console.log('missing property:', key)
-            ret = '!!!'+key+'!!'
+            ret = `!!!${key}!!`
         }
 
         return ret
@@ -42,7 +43,7 @@ function makeInitial(srcData, generator) {
     return template
 }
 
-function getImports(properties) {
+function genImports(properties) {
     var result = new Set()
     for(var propName in properties) {
         var props = properties[propName]
@@ -74,16 +75,20 @@ function genNames(properties) {
     for(var propName in properties) {
         if (propName !== 'children') {
             var props = properties[propName]
-            if(props['x-source'] == 'inject') {
-                inject += '\t/* '+JSON.stringify(props)+' */\n'
+            if(props['x-source'] === 'inject') {
+                inject += `\t/* ${JSON.stringify(props)} */\n`
                 inject += '\t@Inject\n'
-                if(props['x-sourceName']) {
-                    inject += '\t@Named(value ="'+props['x-sourceName']+'")\n'
+
+                var sourceName = props['x-sourceName'];
+                if(sourceName) {
+                    inject += `\t@Named(value ="${sourceName}")\n`
                 }
-                if(props['x-default'] === "" || props['x-default']) {
-                    inject += '\t@Default(values ="'+props['x-default']+'")\n'
+
+                var x_default = props['x-default'];
+                if(x_default === "" || x_default) {
+                    inject += `\t@Default(values ="${x_default}")\n`
                 }
-                if(props['x-form-type'] === ('collection')) {
+                if(props['x-form-type'] === 'collection') {
                     if (Object.keys(props['properties']).length > 1 || props['x-form-multifield'] === "true" || props['x-form-multifield'] === true) {
                         inject += '\tprivate List<IComponent> '
                     } else {
@@ -92,15 +97,12 @@ function genNames(properties) {
                 }  else {
                     inject += '\tprivate String '
                 }
-                inject += propName
-                inject += ';'
-                inject += '\n'
-                inject += '\n'
+                inject += `${propName};\n\n`
                 var annotate = props['x-annotate']
                 if (annotate) {
                     inject += genNamesAnnotates(propName, annotate)
                 }
-            } else if(props['x-form-type'] === ('reference')) {
+            } else if(props['x-form-type'] === 'reference') {
                 inject += genNames(props.properties)
             }
         }
@@ -129,11 +131,11 @@ function genGetters(properties, customGetters) {
     inject = ''
     for(var propName in properties) {
         var getterName = propName.charAt(0).toUpperCase()+propName.slice(1)
-        if (propName !== 'children' && (customGetters === null || !customGetters.includes('public String get' + getterName + '()'))) {
+        if (propName !== 'children' && (customGetters === null || !customGetters.includes(`public String get${getterName}()`))) {
             var props = properties[propName]
             if(props['x-source'] == 'inject') {
-                inject += '\t/* '+JSON.stringify(props)+' */\n'
-                if(props['x-form-type'] === ('collection')) {
+                inject += `\t/* ${JSON.stringify(props)} */\n`
+                if(props['x-form-type'] === 'collection') {
                      if (Object.keys(props['properties']).length > 1 || props['x-form-multifield'] === "true" || props['x-form-multifield'] === true) {
                         inject += '\tpublic List<IComponent> get'
                     } else {
@@ -142,11 +144,9 @@ function genGetters(properties, customGetters) {
                 } else {
                     inject += '\tpublic String get'
                 }
-                inject += getterName + '() {\n'
-                inject += '\t\treturn '+propName+';\n'
-                inject += '\t}'
-                inject += '\n'
-                inject += '\n'
+                inject += `${getterName}() {\n`
+                inject += `\t\treturn ${propName};\n`
+                inject += '\t}\n\n'
                 var annotate = props['x-annotate']
                 if (annotate) {
                     inject += genGettersAnnotates(propName, annotate)

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -44,20 +44,28 @@ function makeInitial(srcData, generator) {
     return template
 }
 
-function genImports(properties) {
-    var result = new Set()
+function genImportsSet(properties, target) {
     for(var propName in properties) {
         var props = properties[propName]
         var annotate = props['x-annotate']
-        if (propName !== 'children' && props['x-source'] == 'inject' && annotate) {
-            forEachSizeAnnotation(annotate, _ => {
-                result.add('com.peregrine.model.api.ImageInfo')
-                result.add('java.awt.Dimension')
-            })
+        if (propName !== 'children') {
+            if(props['x-source'] == 'inject' && annotate) {
+                forEachSizeAnnotation(annotate, _ => {console.log(`${propName}: ${JSON.stringify(props)}`)
+                    target.add('com.peregrine.model.api.ImageInfo')
+                    target.add('java.awt.Dimension')
+                })
+            } else if(props['x-form-type'] === 'reference') {
+                genImportsSet(props.properties, target)
+            }
         }
     }
 
-    return Array.from(result).reduce((all, next) => `${all}import ${next};\n`, '')
+    return target
+}
+
+function genImports(properties) {
+    return Array.from(genImportsSet(properties, new Set()))
+        .reduce((all, next) => `${all}import ${next};\n`, '')
 }
 
 function forEachSizeAnnotation(crudeValues, callback) {

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -31,10 +31,11 @@ function makeInitial(srcData, generator) {
     var template = srcData.replace(/{{.*?}}/g, function(str, p1, offset, s) {
         var key = str.trim().slice(2,str.trim().length-2).trim()
         var ret = data[key]
-        if(!ret) {
+        if(ret === null || ret === undefined) {
             console.log('missing property:', key)
             ret = '!!!'+key+'!!'
         }
+
         return ret
     })
 
@@ -66,8 +67,7 @@ function getImports(properties) {
 */
 function genNames(properties) {
     inject = ''
-    for(var prop in properties) {
-        var propName = prop;
+    for(var propName in properties) {
         if (propName !== 'children') {
             var props = properties[propName]
             if(props['x-source'] == 'inject') {
@@ -125,8 +125,7 @@ function genNamesAnnotates(ownerName, values) {
 */
 function genGetters(properties, customGetters) {
     inject = ''
-    for(var prop in properties) {
-        var propName = prop;
+    for(var propName in properties) {
         var getterName = propName.charAt(0).toUpperCase()+propName.slice(1)
         if (propName !== 'children' && (customGetters === null || !customGetters.includes('public String get' + getterName + '()'))) {
             var props = properties[propName]

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -190,9 +190,14 @@ function genTypes(properties, generator) {
                     if (Object.keys(props['properties']).length > 1 || props['x-form-multifield'] === "true" || props['x-form-multifield'] === true) {
                         var collectionType = props['x-collection-type']
                         if (collectionType) {
+                            var { data } = generator
+                            var { componentPath, package, classNameParent } = data
                             gen(new Generator(generator.src, path.join(path.dirname(generator.dst), `${collectionType}Model.java`), {
-                                ...generator.data,
+                                name: collectionType,
                                 modelName: collectionType,
+                                componentPath: `${componentPath}/${propName}`,
+                                package,
+                                classNameParent,
                                 definitions: {
                                     [collectionType]: props
                                 }

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -48,16 +48,20 @@ function getImports(properties) {
         var props = properties[propName]
         var annotate = props['x-annotate']
         if (propName !== 'children' && props['x-source'] == 'inject' && annotate) {
-            for(var annotatePropName in annotate) {
-                if (annotate[annotatePropName] === "imagesize") {
-                    result.add('com.peregrine.model.api.ImageInfo')
-                    result.add('java.awt.Dimension')
-                }
-            }
+            forEachSizeAnnotation(annotate, _ => {
+                result.add('com.peregrine.model.api.ImageInfo')
+                result.add('java.awt.Dimension')
+            })
         }
     }
 
     return Array.from(result).reduce((all, next) => `${all}import ${next};\n`, '')
+}
+
+function forEachSizeAnnotation(crudeValues, callback) {
+    (typeof crudeValues === 'string' ? [crudeValues] : crudeValues)
+        .filter(a => a === 'size')
+        .forEach(callback)
 }
 
 /**
@@ -104,15 +108,13 @@ function genNames(properties) {
     return inject
 }
 
-function genNamesAnnotates(ownerName, values) {
+function genNamesAnnotates(ownerName, annotate) {
     var result = ''
-    for(var name in values) {
-        if (values[name] === "imagesize") {
-            result += '\t@Inject\n'
-            result += `\t@ImageInfo(name="${ownerName}")\n`
-            result += `\tprivate Dimension ${name};\n\n`
-        }
-    }
+    forEachSizeAnnotation(annotate, _ => {
+        result = '\t@Inject\n'
+        result += `\t@ImageInfo(name="${ownerName}")\n`
+        result += `\tprivate Dimension ${ownerName}Size;\n\n`
+    })
 
     return result
 }
@@ -147,7 +149,7 @@ function genGetters(properties, customGetters) {
                 inject += '\n'
                 var annotate = props['x-annotate']
                 if (annotate) {
-                    inject += genGettersAnnotates(annotate)
+                    inject += genGettersAnnotates(propName, annotate)
                 }
             } else if(props['x-form-type'] === ('reference')) {
                 inject += genGetters(props.properties, customGetters)
@@ -157,15 +159,13 @@ function genGetters(properties, customGetters) {
     return inject
 }
 
-function genGettersAnnotates(values) {
+function genGettersAnnotates(ownerName, annotate) {
     var result = ''
-    for(var name in values) {
-        if (values[name] === "imagesize") {
-            result += `\tpublic Dimension get${name.charAt(0).toUpperCase()}${name.slice(1)}() {\n`
-            result += `\t\treturn ${name};\n`
-            result += '\t}\n\n'
-        }
-    }
+    forEachSizeAnnotation(annotate, _ => {
+        result += `\tpublic Dimension get${ownerName.charAt(0).toUpperCase()}${ownerName.slice(1)}Size() {\n`
+        result += `\t\treturn ${ownerName}Size;\n`
+        result += '\t}\n\n'
+    })
 
     return result
 }

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -42,20 +42,21 @@ function makeInitial(srcData, generator) {
 }
 
 function getImports(properties) {
+    var result = new Set()
     for(var propName in properties) {
         var props = properties[propName]
         var annotate = props['x-annotate']
         if (propName !== 'children' && props['x-source'] == 'inject' && annotate) {
             for(var annotatePropName in annotate) {
                 if (annotate[annotatePropName] === "imagesize") {
-                    return 'import com.peregrine.model.api.ImageInfo;\n' + 
-                        'import java.awt.Dimension;\n';
+                    result.add('com.peregrine.model.api.ImageInfo')
+                    result.add('java.awt.Dimension')
                 }
             }
         }
     }
 
-    return ''
+    return Array.from(result).reduce((all, next) => `${all}import ${next};\n`, '')
 }
 
 /**

--- a/lib/htmltovue.js
+++ b/lib/htmltovue.js
@@ -90,7 +90,6 @@ function htmltovue(name, container, compile, deploy, dialog, model, vue, samplee
 
     const projectName = settings.appname
 
-    let templatePath = templates.getPath()
     let projectPath = process.cwd()
     // should check that we are in the root of the project
     // console.log('template  path:',templatePath)

--- a/templates/model.java.template.java
+++ b/templates/model.java.template.java
@@ -13,6 +13,8 @@ import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+{{ imports }}
+
 /*
     //GEN[:DATA
     //GEN]
@@ -32,7 +34,7 @@ import javax.inject.Named;
 //GEN]
 public class {{ modelName }}Model extends {{ classNameParent }} {
 
-    public {{ modelName }}Model(Resource r) { super(r); }
+    public {{ modelName }}Model(final Resource r) { super(r); }
 
     //GEN[:INJECT
     //GEN]


### PR DESCRIPTION
Implements [peregrine-cms#460](https://github.com/headwirecom/peregrine-cms/issues/460).
Complements (and needs to work) [peregrine-cms#671](https://github.com/headwirecom/peregrine-cms/pull/671) - will run on [peregrine-cms/develop-sling12](https://github.com/headwirecom/peregrine-cms/tree/develop-sling12) once merged.
Used in [themeclean-flex#175](https://github.com/headwirecom/themeclean-flex/pull/175).